### PR TITLE
Fixed Link CTpermanent.html

### DIFF
--- a/Teaching/Teaching Gothenburg/CT/permanent/CTpermanent.html
+++ b/Teaching/Teaching Gothenburg/CT/permanent/CTpermanent.html
@@ -110,7 +110,7 @@
     <td class="tg-0lax">10.</td>
     <td class="tg-tbam">Monoidal (closed) categories and enrichments.</td>
     <td class="tg-z15b"></td>
-    <td class="tg-tbam"><a href="https://math.jhu.edu/~eriehl/cathtpy.pdf"><i class="fas fa-sticky-note"> Chap. 3.</td>
+    <td class="tg-tbam"><a href="https://emilyriehl.github.io/files/cathtpy.pdf"><i class="fas fa-sticky-note"> Chap. 3.</td>
   </tr> 
 
 


### PR DESCRIPTION
Updated a no longer working link for lecture 10, since Emily Riehl migrated websites.